### PR TITLE
refactor: improve maintainability and documentation across core classes

### DIFF
--- a/engine/src/main/java/pro/verron/officestamper/api/OfficeStamperConfiguration.java
+++ b/engine/src/main/java/pro/verron/officestamper/api/OfficeStamperConfiguration.java
@@ -273,6 +273,8 @@ public interface OfficeStamperConfiguration {
     /// @param name   the name of the custom function to be added
     /// @param class0 the class type for the first parameter of the bi-function
     /// @param class1 the class type for the second parameter of the bi-function
+    /// @param <T>    the type of the first parameter
+    /// @param <U>    the type of the second parameter
     ///
     /// @return an instance of NeedsBiFunctionImpl parameterized with the provided types
     <T, U> NeedsBiFunctionImpl<T, U> addCustomFunction(String name, Class<T> class0, Class<U> class1);

--- a/engine/src/main/java/pro/verron/officestamper/preset/CommentProcessorFactory.java
+++ b/engine/src/main/java/pro/verron/officestamper/preset/CommentProcessorFactory.java
@@ -1,6 +1,7 @@
 package pro.verron.officestamper.preset;
 
 import org.springframework.lang.Nullable;
+import pro.verron.officestamper.api.OfficeStamperException;
 
 /// Factory class to create the correct comment processor for a given comment.
 ///
@@ -8,6 +9,11 @@ import org.springframework.lang.Nullable;
 /// @version ${version}
 /// @since 1.6.4
 public class CommentProcessorFactory {
+
+    private CommentProcessorFactory() {
+        throw new OfficeStamperException("CommentProcessorFactory cannot be instantiated");
+    }
+
     /// Used to resolve a table in the template document.
     /// Take the table passed-in to fill an existing Tbl object in the document.
     ///

--- a/engine/src/main/java/pro/verron/officestamper/preset/ExceptionResolvers.java
+++ b/engine/src/main/java/pro/verron/officestamper/preset/ExceptionResolvers.java
@@ -43,7 +43,7 @@ public class ExceptionResolvers {
 
     /// The defaulting resolver class will handle exceptions by returning a default value.
     /// It logs the exception message and the stack trace if tracing is enabled.
-    ///
+    /// @param value The default value to be returned if an exception occurs.
     /// @return An instance of `ExceptionResolver` that returns a default value.
     public static ExceptionResolver defaulting(String value) {
         return new DefaultingResolver(value, logger.isTraceEnabled());

--- a/engine/src/main/java/pro/verron/officestamper/preset/Image.java
+++ b/engine/src/main/java/pro/verron/officestamper/preset/Image.java
@@ -107,7 +107,7 @@ public final class Image {
     /// @deprecated use the [#newRun(DocxPart, String, String)] method directly to generate a Run with Inline
     /// Drawing
     @Deprecated(since = "2.6", forRemoval = true)
-    public byte[] getImageBytes(byte test) {
+    public byte[] getImageBytes() {
         return imageBytes;
     }
 }


### PR DESCRIPTION
- Prevent instantiation of `CommentProcessorFactory` by adding a private constructor.
- Enhance Javadoc comments in `ExceptionResolvers` and `OfficeStamperConfiguration` to clarify method parameters and generics.
- Fix signature of `getImageBytes` in `Image` by removing unused parameter.