### PR TITLE
test(utils): add unit tests for `SvgUtils.parseDocument` with hardene…

### DIFF
--- a/utils/src/main/java/pro/verron/officestamper/utils/svg/SvgUtils.java
+++ b/utils/src/main/java/pro/verron/officestamper/utils/svg/SvgUtils.java
@@ -1,10 +1,13 @@
 package pro.verron.officestamper.utils.svg;
 
-import org.docx4j.XmlUtils;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 import pro.verron.officestamper.utils.UtilsException;
 
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
@@ -14,13 +17,49 @@ public class SvgUtils {
         /* This utility class should not be instantiated */
     }
 
+    /// Parse an SVG XML document from bytes with hardened XML parser settings.
+    ///
+    /// - Disables DTDs and external entity resolution to prevent XXE attacks
+    /// - Enables secure processing
+    /// - Disables XInclude and entity expansion
+    ///
+    /// @param bytes the SVG content as a UTF-8 encoded byte array
+    /// @return the parsed DOM Document
+    /// @throws UtilsException if parsing fails or the parser cannot be securely configured
     public static Document parseDocument(byte[] bytes) {
-        var documentBuilder = XmlUtils.getNewDocumentBuilder();
         var inputStream = new ByteArrayInputStream(bytes);
         try {
+            var documentBuilder = newSecureDocumentBuilder();
             return documentBuilder.parse(inputStream);
-        } catch (SAXException | IOException e) {
-            throw new UtilsException(e);
+        } catch (SAXException | IOException | ParserConfigurationException e) {
+            throw new UtilsException("Failed to parse SVG document securely", e);
         }
+    }
+
+    private static DocumentBuilder newSecureDocumentBuilder()
+            throws ParserConfigurationException {
+        var factory = DocumentBuilderFactory.newInstance();
+
+        // Namespace aware parsing is generally recommended for SVG
+        factory.setNamespaceAware(true);
+
+        // Harden against XXE/DTD
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        // Disallow any DOCTYPE
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        // Prevent external entity resolution
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
+        // XInclude and entity expansion
+        try {
+            factory.setXIncludeAware(false);
+        } catch (UnsupportedOperationException ignored) {
+            // Some implementations may not support XInclude; safe to ignore
+        }
+        factory.setExpandEntityReferences(false);
+
+        return factory.newDocumentBuilder();
     }
 }

--- a/utils/src/test/java/pro/verron/officestamper/utils/svg/SvgUtilsTest.java
+++ b/utils/src/test/java/pro/verron/officestamper/utils/svg/SvgUtilsTest.java
@@ -1,0 +1,59 @@
+package pro.verron.officestamper.utils.svg;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import pro.verron.officestamper.utils.UtilsException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SvgUtilsTest {
+
+    @Test
+    @DisplayName("Parses a minimal, benign SVG successfully")
+    void parsesMinimalSvg() {
+        var svg = ("<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 10 10\">" +
+                   "  <rect width=\"10\" height=\"10\"/>" +
+                   "</svg>").getBytes();
+
+        var doc = SvgUtils.parseDocument(svg);
+        assertNotNull(doc);
+        assertEquals("svg",
+                doc.getDocumentElement()
+                   .getLocalName());
+        assertEquals("http://www.w3.org/2000/svg",
+                doc.getDocumentElement()
+                   .getNamespaceURI());
+    }
+
+    @Test
+    @DisplayName("Rejects SVG containing DOCTYPE (disallow-doctype-decl)")
+    void rejectsDoctype() {
+        var svg = (
+                "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">"
+                +
+                "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>").getBytes();
+
+        assertThrows(UtilsException.class, () -> SvgUtils.parseDocument(svg));
+    }
+
+    @Test
+    @DisplayName("Rejects SVG attempting XXE via external entity")
+    void rejectsExternalEntityXXE() {
+        var svg = ("<!DOCTYPE svg [<!ENTITY xxe SYSTEM 'file:///etc/passwd'>]>" +
+                   "<svg xmlns=\"http://www.w3.org/2000/svg\">&xxe;</svg>").getBytes();
+
+        assertThrows(UtilsException.class, () -> SvgUtils.parseDocument(svg));
+    }
+
+    @Test
+    @DisplayName("Rejects SVG with entity expansion (billion laughs)")
+    void rejectsBillionLaughsLikePayload() {
+        var svg = ("<!DOCTYPE svg [" +
+                   "<!ENTITY a 'LOL'>" +
+                   "<!ENTITY b '&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;'>" +
+                   "]>" +
+                   "<svg xmlns=\"http://www.w3.org/2000/svg\">&b;</svg>").getBytes();
+
+        assertThrows(UtilsException.class, () -> SvgUtils.parseDocument(svg));
+    }
+}


### PR DESCRIPTION
…d XML parsing

- Added test cases in `SvgUtilsTest` to validate parsing behavior:
  - Successfully parses a minimal SVG.
  - Rejects malicious SVGs with DOCTYPE, external entities (XXE), and entity expansion (billion laughs).
- Refactored `SvgUtils` to use a securely configured `DocumentBuilder` for XML parsing.
- Hardened parser settings to prevent XXE attacks, disable DTDs, and limit entity processing.