### PR TITLE
Fix #796: brace-balanced placeholder tokenizer (nested braces, SpEL l…

### DIFF
--- a/engine/src/main/java/pro/verron/officestamper/api/PlaceholderHooker.java
+++ b/engine/src/main/java/pro/verron/officestamper/api/PlaceholderHooker.java
@@ -6,113 +6,173 @@ import org.docx4j.wml.P;
 import pro.verron.officestamper.utils.wml.WmlUtils;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.regex.Pattern;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SequencedMap;
 
+import static java.util.Comparator.comparingInt;
 import static pro.verron.officestamper.utils.wml.WmlUtils.asString;
 import static pro.verron.officestamper.utils.wml.WmlUtils.insertSmartTag;
 
-/// The [PlaceholderHooker] class is a pre-processor that prepares inline
-/// placeholders in a [WordprocessingMLPackage]
-/// document. It searches for placeholders that match a given pattern and wraps
-/// them with a specified XML element to
-/// ensure proper processing by the OfficeStamper engine.
+/// The [PlaceholderHooker] class is a pre-processor that prepares inline placeholders in a
+/// [WordprocessingMLPackage] document. It searches for placeholders introduced by one of the configured opening
+/// delimiters and wraps them with a smart tag, so the OfficeStamper engine can process them later.
 ///
-/// This pre-processor is typically used to identify and mark inline expressions
-/// within paragraphs, making them
-/// recognizable for subsequent processing steps.
-public class PlaceholderHooker implements PreProcessor {
+/// ## Brace balancing
+///
+/// A placeholder ends at the closing brace that *balances* its opening brace, not at the first closing brace
+/// encountered. Braces nested inside the placeholder are therefore part of the expression, which is what makes SpEL
+/// inline lists and inline maps usable as placeholders:
+///
+/// ```text
+/// ${ {1, 2, 3} }              -> expression " {1, 2, 3} "   (a SpEL inline list)
+/// ${ {'a': 1, 'b': 2} }       -> expression " {'a': 1, 'b': 2} " (a SpEL inline map)
+/// ${ {1, 2, 3}.?[#this > 1] } -> expression " {1, 2, 3}.?[#this > 1] "
+/// ```
+///
+/// ## Malformed placeholders
+///
+/// An opening delimiter that is never balanced by a closing brace is *malformed*. Rather than leaving the stray
+/// delimiter behind — and rather than letting the text that follows it be interpreted as further placeholders — the
+/// malformed placeholder spans the remainder of the paragraph and is captured verbatim, delimiters included. The
+/// engine then fails to parse it and hands it to the configured [ExceptionResolver], so the failure is reported
+/// through the usual channel instead of silently corrupting the output.
+///
+/// ## Single pass
+///
+/// All delimiters are matched in one left-to-right pass, and scanning resumes *after* each placeholder that has been
+/// wrapped. Consequently a placeholder nested inside another one is part of the outer expression and is never wrapped
+/// on its own.
+public class PlaceholderHooker
+        implements PreProcessor {
 
-    private final Pattern pattern;
-    private final String element;
+    private static final char OPENING_BRACE = '{';
+    private static final char CLOSING_BRACE = '}';
 
+    private final SequencedMap<String, String> elementByOpening;
 
-    /// Constructs a new [PlaceholderHooker] instance with the specified regular
-    /// expression and XML element
-    /// name.
+    /// Constructs a new [PlaceholderHooker] recognizing a single opening delimiter.
     ///
-    /// @param regex   the regular expression pattern used to identify inline
-    /// placeholders in the document. This
-    ///         pattern should contain at least two capturing groups where the
-    /// second group represents the actual
-    ///         placeholder content.
-    /// @param element the name of the XML element to wrap around identified
-    /// placeholders. This element will be
-    ///         used to mark the placeholders for further processing.
-    public PlaceholderHooker(String regex, String element) {
-        this(Pattern.compile(regex, Pattern.DOTALL), element);
+    /// @param opening the literal opening delimiter of a placeholder, for instance `${` or `#{`. It must end with
+    ///         an opening brace.
+    /// @param element the name of the smart tag type to wrap matching placeholders with.
+    public PlaceholderHooker(String opening, String element) {
+        this(Map.of(opening, element));
     }
 
-
-    /// Constructs a new [PlaceholderHooker] instance with the specified pattern
-    /// and XML element name.
+    /// Constructs a new [PlaceholderHooker] recognizing several opening delimiters in a single pass.
     ///
-    /// @param pattern the compiled regular expression pattern used to identify
-    /// inline placeholders in the
-    ///         document. This pattern should contain at least two capturing
-    /// groups where the second group represents
-    ///         the actual placeholder content.
-    /// @param element the name of the XML element to wrap around identified
-    /// placeholders. This element will be
-    ///         used to mark the placeholders for further processing.
-    public PlaceholderHooker(Pattern pattern, String element) {
-        this.pattern = pattern;
-        this.element = element;
+    /// @param elementByOpening the smart tag type to use for each literal opening delimiter. Every delimiter must
+    ///         end with an opening brace. When several delimiters could match at the same position, the longest one
+    ///         wins.
+    public PlaceholderHooker(Map<String, String> elementByOpening) {
+        this.elementByOpening = elementByOpening.entrySet()
+                                                .stream()
+                                                .sorted(comparingInt((Map.Entry<String, String> e) -> e.getKey()
+                                                                                                       .length())
+                                                        .reversed())
+                                                .collect(LinkedHashMap::new,
+                                                        (map, e) -> map.put(validate(e.getKey()), e.getValue()),
+                                                        LinkedHashMap::putAll);
+    }
+
+    private static String validate(String opening) {
+        if (opening.isEmpty() || opening.charAt(opening.length() - 1) != OPENING_BRACE)
+            throw new OfficeStamperException(
+                    "A placeholder opening delimiter must end with '%c', but was '%s'".formatted(OPENING_BRACE,
+                            opening));
+        return opening;
     }
 
     @Override
     public void process(WordprocessingMLPackage document) {
-        var visitor = new ParagraphCollector(pattern);
+        var visitor = new ParagraphCollector(elementByOpening.keySet());
         WmlUtils.visitDocument(document, visitor);
-        for (var paragraph : visitor.paragraphs()) {
-            var string = asString(paragraph);
-            var matcher = pattern.matcher(string);
-            // Iterates matches; replaces placeholder with a smart tag
-            while (matcher.find()) {
-                var start = matcher.start(1);
-                var end = matcher.end(1);
-                var placeholder = matcher.group(2);
-                insertSmartTag(element, paragraph, placeholder, start, end);
-                string = asString(paragraph);
-                matcher = pattern.matcher(string);
+        for (var paragraph : visitor.paragraphs()) hook(paragraph);
+    }
+
+    /// Wraps every placeholder of the given paragraph with a smart tag, in a single left-to-right pass.
+    private void hook(P paragraph) {
+        var text = asString(paragraph);
+        var cursor = 0;
+        while (cursor < text.length()) {
+            var opening = openingAt(text, cursor);
+            if (opening.isEmpty()) {
+                cursor++;
+                continue;
             }
+            var delimiter = opening.get();
+            var placeholder = scan(text, cursor, delimiter);
+            var expression = placeholder.expression();
+            insertSmartTag(elementByOpening.get(delimiter), paragraph, expression, cursor, placeholder.end());
+            // The tag holds exactly the expression, delimiters stripped, so scanning resumes right after it.
+            cursor += expression.length();
+            text = asString(paragraph);
         }
     }
 
-    /// A [TraversalUtilVisitor] implementation that collects paragraphs
-    /// matching a given pattern.
-    ///
-    /// This class is used to traverse a document and collect all paragraph
-    /// elements ([P]) that match a specified
-    /// regular expression pattern. The collected paragraphs can be retrieved
-    /// using the [#paragraphs()] method.
-    public static class ParagraphCollector extends TraversalUtilVisitor<P> {
+    /// Returns the opening delimiter starting at the given index, if any.
+    private Optional<String> openingAt(String text, int index) {
+        return elementByOpening.keySet()
+                               .stream()
+                               .filter(opening -> text.startsWith(opening, index))
+                               .findFirst();
+    }
 
-        private final Pattern pattern;
+    /// Scans a placeholder starting at `start`, balancing nested braces.
+    ///
+    /// When the opening brace is balanced, the placeholder stops right after the matching closing brace and the
+    /// expression excludes both delimiters. When it is never balanced, the placeholder is malformed: it spans the rest
+    /// of the text and the expression keeps the delimiters, so that the engine reports it as unparseable.
+    private static Placeholder scan(String text, int start, String opening) {
+        var depth = 1;
+        for (var index = start + opening.length(); index < text.length(); index++) {
+            var character = text.charAt(index);
+            if (character == OPENING_BRACE) depth++;
+            else if (character == CLOSING_BRACE && --depth == 0)
+                return new Placeholder(index + 1, text.substring(start + opening.length(), index));
+        }
+        return new Placeholder(text.length(), text.substring(start));
+    }
+
+    /// A placeholder located in a paragraph's text.
+    ///
+    /// @param end the index right after the placeholder.
+    /// @param expression the expression the smart tag will carry.
+    private record Placeholder(int end, String expression) {}
+
+    /// A [TraversalUtilVisitor] implementation that collects the paragraphs possibly holding a placeholder.
+    ///
+    /// This class is used to traverse a document and collect all paragraph elements ([P]) containing at least one of
+    /// the given opening delimiters. The collected paragraphs can be retrieved using the [#paragraphs()] method.
+    public static class ParagraphCollector
+            extends TraversalUtilVisitor<P> {
+
+        private final List<String> openings;
         private final List<P> results = new ArrayList<>();
 
-
-        /// Constructs a new [ParagraphCollector] with the specified pattern.
+        /// Constructs a new [ParagraphCollector] with the specified opening delimiters.
         ///
-        /// @param pattern the regular expression pattern to match against
-        /// paragraphs
-        public ParagraphCollector(Pattern pattern) {
-            this.pattern = pattern;
+        /// @param openings the opening delimiters to look for in paragraphs
+        public ParagraphCollector(Collection<String> openings) {
+            this.openings = List.copyOf(openings);
         }
 
         @Override
         public void apply(P element) {
-            var matcher = pattern.asPredicate();
             var string = asString(element);
-            if (matcher.test(string)) {
+            if (openings.stream()
+                        .anyMatch(string::contains)) {
                 results.add(element);
             }
         }
 
-        /// Returns the list of collected paragraphs that matched the pattern.
+        /// Returns the list of collected paragraphs possibly holding a placeholder.
         ///
-        /// @return an unmodifiable list of paragraphs matching the specified
-        ///  pattern
+        /// @return a list of paragraphs containing at least one opening delimiter
         public List<P> paragraphs() {
             return results;
         }

--- a/engine/src/main/java/pro/verron/officestamper/preset/ExceptionResolvers.java
+++ b/engine/src/main/java/pro/verron/officestamper/preset/ExceptionResolvers.java
@@ -61,12 +61,12 @@ public class ExceptionResolvers {
     private record DefaultingResolver(String value, boolean tracing)
             implements ExceptionResolver {
 
-        private static final Logger logger = LoggerFactory.getLogger(DefaultingResolver.class);
-
         @Override
         public Insert resolve(String expression, String message, Exception cause) {
-            if (tracing) logger.warn(message, cause);
-            else logger.warn(message);
+            var description = "Placeholder '%s' could not be resolved; falling back to the default value '%s'. %s"
+                    .formatted(expression, value, message);
+            if (tracing) logger.warn(description, cause);
+            else logger.warn(description);
             return new Insert(newRun(value));
         }
     }
@@ -76,8 +76,10 @@ public class ExceptionResolvers {
 
         @Override
         public Insert resolve(String expression, String message, Exception cause) {
-            if (tracing) logger.warn(message, cause);
-            else logger.warn(message);
+            var description = "Placeholder '%s' could not be resolved; passing it through unchanged. %s"
+                    .formatted(expression, message);
+            if (tracing) logger.warn(description, cause);
+            else logger.warn(description);
             return new Insert(newRun(template.formatted(expression)));
         }
     }
@@ -87,8 +89,10 @@ public class ExceptionResolvers {
 
         @Override
         public Insert resolve(String expression, String message, Exception cause) {
-            if (tracing) throw new OfficeStamperException(message, cause);
-            else throw new OfficeStamperException(message);
+            var description = "Placeholder '%s' could not be resolved and no fallback is configured. %s"
+                    .formatted(expression, message);
+            if (tracing) throw new OfficeStamperException(description, cause);
+            else throw new OfficeStamperException(description);
         }
     }
 }

--- a/engine/src/main/java/pro/verron/officestamper/preset/OfficeStamperConfigurations.java
+++ b/engine/src/main/java/pro/verron/officestamper/preset/OfficeStamperConfigurations.java
@@ -176,8 +176,8 @@ public class OfficeStamperConfigurations {
     public static OfficeStamperConfiguration minimal() {
         var configuration = raw();
         configuration.addResolver(Resolvers.fallback("\n"));
-        configuration.addPreprocessor(Preprocessors.preparePlaceholders("(\\$\\{([^{]+?)})", "placeholder"));
-        configuration.addPreprocessor(Preprocessors.preparePlaceholders("(\\#\\{([^{]+?)})", "inlineProcessor"));
+        configuration.addPreprocessor(Preprocessors.preparePlaceholders("${", "placeholder"));
+        configuration.addPreprocessor(Preprocessors.preparePlaceholders("#{", "inlineProcessor"));
         configuration.addPreprocessor(Preprocessors.prepareCommentProcessor());
         configuration.addPostprocessor(Postprocessors.removeTags("officestamper"));
         configuration.addPostprocessor(Postprocessors.removeComments());

--- a/engine/src/main/java/pro/verron/officestamper/preset/Preprocessors.java
+++ b/engine/src/main/java/pro/verron/officestamper/preset/Preprocessors.java
@@ -50,13 +50,17 @@ public class Preprocessors {
         return new RemoveMalformedComments();
     }
 
-    /// Returns a [PreProcessor] object that prepares inline placeholders based on the provided regex and element name.
+    /// Returns a [PreProcessor] object that prepares inline placeholders introduced by the given opening delimiter.
+    /// The matching closing brace is found by brace balancing, so expressions may nest braces freely (for instance a
+    /// SpEL inline list or map).
     ///
-    /// @param regex the regular expression used to identify placeholders in the document
-    /// @param element the name of the smart tag element to be used for the placeholders
+    /// @param opening the literal opening delimiter of a placeholder, for instance `${` or `#{`. It must end with an
+    ///         opening brace.
+    /// @param element the name of the smart tag type to wrap matching placeholders with.
     /// @return a [PreProcessor] object that prepares inline placeholders.
-    public static PreProcessor preparePlaceholders(String regex, String element) {
-        return new PlaceholderHooker(regex, element);
+    /// @see PlaceholderHooker
+    public static PreProcessor preparePlaceholders(String opening, String element) {
+        return new PlaceholderHooker(opening, element);
     }
 
 

--- a/engine/src/site/asciidoc/how-does-it-works.adoc
+++ b/engine/src/site/asciidoc/how-does-it-works.adoc
@@ -30,23 +30,30 @@ Before the main pass, standard configurations run a preprocessor that scans para
 This detaches expressions from their original text runs and makes them easy to iterate during the main processing pass.
 
 - Class: `pro.verron.officestamper.api.PlaceholderHooker`
-- Registered by: `pro.verron.officestamper.preset.Preprocessors.preparePlaceholders(String regex, String type)`
+- Registered by: `pro.verron.officestamper.preset.Preprocessors.preparePlaceholders(String opening, String type)`
 - Standard wiring (`OfficeStamperConfigurations.standard()`):
 
 [source,java]
 ----
-// In OfficeStamperConfigurations.standard():
-configuration.addPreprocessor(Preprocessors.removeMalformedComments());
-configuration.addPreprocessor(Preprocessors.preparePlaceholders("(\\#\\{([^{]+?)})", "inlineProcessor"));
-configuration.addPreprocessor(Preprocessors.preparePlaceholders("(\\$\\{([^{]+?)})", "placeholder"));
+// In OfficeStamperConfigurations.minimal():
+configuration.addPreprocessor(Preprocessors.preparePlaceholders("${", "placeholder"));
+configuration.addPreprocessor(Preprocessors.preparePlaceholders("#{", "inlineProcessor"));
 configuration.addPreprocessor(Preprocessors.prepareCommentProcessor());
 ----
 
 How it works (simplified):
 
-- Each paragraph is stringified; a regex finds markers.
-- Group 1 is the full marker (e.g., `${...}`), group 2 is the inner expression.
-- The preprocessor replaces the matched text range with a `CTSmartTagRun` whose `type` attribute is set to the provided value (`"placeholder"` or `"inlineProcessor"`) and whose content is the raw expression text.
+- Each paragraph is stringified; the hooker scans it left-to-right for the configured opening delimiters (e.g., `${` or `#{`).
+- A placeholder ends at the closing brace that *balances* its opening brace, so expressions may nest braces freely. This is what makes SpEL inline lists and inline maps usable as placeholders:
++
+[source,text]
+----
+${ {1, 2, 3} }              -> expression " {1, 2, 3} "   (a SpEL inline list)
+${ {'a': 1, 'b': 2} }       -> expression " {'a': 1, 'b': 2} " (a SpEL inline map)
+${ {1, 2, 3}.?[#this > 1] } -> expression " {1, 2, 3}.?[#this > 1] "
+----
+- An opening delimiter that is never balanced by a closing brace is *malformed*. It spans the remainder of the paragraph and is captured verbatim (delimiters included), so the engine fails to parse it and hands it to the configured `ExceptionResolver` instead of leaving a stray delimiter behind.
+- For every matched placeholder the hooker replaces the corresponding text range with a `CTSmartTagRun` whose `type` attribute is set to the provided value (`"placeholder"` or `"inlineProcessor"`) and whose content is the inner expression (delimiters stripped, unless malformed).
 Implementation detail: it uses `WmlUtils.insertSmartTag(type, paragraph, expression, start, end)`.
 
 === 1.2. Post-processing: cleaning up markup
@@ -71,7 +78,7 @@ Customize/disable:
 ----
 // Start from the raw configuration and add only what you need
 var cfg = OfficeStamperConfigurations.raw();
-cfg.addPreprocessor(Preprocessors.preparePlaceholders("(\\$\\{(.+?)})", "placeholder"));
+cfg.addPreprocessor(Preprocessors.preparePlaceholders("${", "placeholder"));
 
 // Or tweak the standard config by adding/removing preprocessors
 var std = OfficeStamperConfigurations.standard();

--- a/engine/src/site/asciidoc/release-notes.adoc
+++ b/engine/src/site/asciidoc/release-notes.adoc
@@ -19,6 +19,7 @@
 * **Documentation**: Rearranged documentation for better Maven site and GitHub visibility.
 * **CI/CD**: Fixed the GitHub release workflow.
 * **Modularization**: Extracted `imageio` and `asciidoc` modules into separate repositories.
+* **Placeholder tokenizer rewrite** (issue #{os}/issues/796[#796]): `PlaceholderHooker` no longer relies on a regex that forbade nested braces. It now scans for opening delimiters (`${`, `#{`, …) and balances braces, so SpEL inline lists (`${ {1, 2, 3} }`) and inline maps (`${ {'a': 1} }`) are valid placeholders. A placeholder whose opening brace is never balanced is captured verbatim and handed to the configured `ExceptionResolver` instead of being left behind as a stray `${`.
 
 == {proj}/v3.4[v3.4]
 

--- a/engine/src/test/java/pro/verron/officestamper/test/PlaceholderPreprocessorTest.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/PlaceholderPreprocessorTest.java
@@ -11,7 +11,7 @@ class PlaceholderPreprocessorTest {
 
     @Test
     void process() {
-        var preparePlaceholders = new PlaceholderHooker("(#\\{([^{]+?)})", "inlineProcessor");
+        var preparePlaceholders = new PlaceholderHooker("#{", "inlineProcessor");
         var document = makeWordResource("Hello, #{name}!");
         var before = toAsciidoc(document);
         assertEquals("""

--- a/engine/src/test/java/pro/verron/officestamper/test/SpelInjectionTest.java
+++ b/engine/src/test/java/pro/verron/officestamper/test/SpelInjectionTest.java
@@ -1,21 +1,25 @@
 package pro.verron.officestamper.test;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import pro.verron.officestamper.api.OfficeStamperException;
+import pro.verron.officestamper.preset.ExceptionResolvers;
 import pro.verron.officestamper.preset.OfficeStamperConfigurations;
 import pro.verron.officestamper.test.utils.ContextFactory;
 
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static pro.verron.asciidoc.compiler.AsciiDocCompiler.toAsciidoc;
 import static pro.verron.officestamper.preset.OfficeStampers.docxPackageStamper;
 import static pro.verron.officestamper.test.utils.ContextFactory.mapContextFactory;
-import static pro.verron.officestamper.test.utils.ContextFactory.objectContextFactory;
+import static pro.verron.officestamper.test.utils.DocxFactory.makeWordResource;
 import static pro.verron.officestamper.test.utils.ResourceUtils.getWordResource;
 
 
@@ -23,18 +27,81 @@ import static pro.verron.officestamper.test.utils.ResourceUtils.getWordResource;
 class SpelInjectionTest {
 
     static Stream<Arguments> factories() {
-        return Stream.of(argumentSet("obj", objectContextFactory()), argumentSet("map", mapContextFactory()));
+        return Stream.of(
+                org.junit.jupiter.params.provider.Arguments.argumentSet("obj", ContextFactory.objectContextFactory()),
+                org.junit.jupiter.params.provider.Arguments.argumentSet("map", mapContextFactory()));
     }
 
-    @DisplayName("Ensure dangerous SpeL injection throws an error, and not execute directly")
+    @DisplayName("Ensure dangerous SpEL injection throws an error, and not execute directly")
     @MethodSource("factories")
     @ParameterizedTest
-    void spelInjectionTest(ContextFactory factory) {
+    void spelInjectionFromBinaryResourceThrows(ContextFactory factory) {
         var context = factory.empty();
         var template = getWordResource("SpelInjectionTest.docx");
         var configuration = OfficeStamperConfigurations.standard();
         var stamper = docxPackageStamper(configuration);
         assertThrows(OfficeStamperException.class, () -> stamper.stamp(template, context));
         assertDoesNotThrow(() -> "Does not throw", "Since VM is still up.");
+    }
+
+    @DisplayName("Issue #796: a malformed placeholder whose opening brace is never balanced is handed to the exception "
+            + "resolver instead of being left as a stray literal")
+    @Test
+    void malformedPlaceholderIsResolvedByResolver() {
+        var context = mapContextFactory().empty();
+        var template = makeWordResource("""
+                ${#{T(java.lang.System).exit(0)}
+
+                The rest of the document keeps being processed.
+                """);
+        var configuration = OfficeStamperConfigurations.minimal();
+        configuration.setExceptionResolver(ExceptionResolvers.defaulting("__________"));
+        var stamper = docxPackageStamper(configuration);
+        var result = stamper.stamp(template, context);
+        var actual = toAsciidoc(result);
+        assertTrue(actual.contains("__________"),
+                "The malformed placeholder should be replaced by the resolver's default value");
+        assertTrue(actual.contains("The rest of the document keeps being processed."),
+                "The rest of the document should keep being processed");
+        assertFalse(actual.contains("exit"), "The dangerous expression must never be evaluated");
+        assertFalse(actual.contains("${"), "No stray '${' should be left behind");
+    }
+
+    @DisplayName("The two-braces injection attempt is still blocked and throws under the throwing resolver")
+    @Test
+    void wellFormedDangerousPlaceholderStillThrows() {
+        var context = mapContextFactory().empty();
+        var template = makeWordResource("${#{T(java.lang.System).exit(0)}}");
+        var configuration = OfficeStamperConfigurations.standard();
+        var stamper = docxPackageStamper(configuration);
+        assertThrows(OfficeStamperException.class, () -> stamper.stamp(template, context));
+        assertDoesNotThrow(() -> "Does not throw", "Since VM is still up.");
+    }
+
+    @DisplayName("SpEL inline lists can be used as placeholders (brace balancing)")
+    @Test
+    void inlineListPlaceholderResolves() {
+        var context = mapContextFactory().empty();
+        var template = makeWordResource("Numbers: ${ {1, 2, 3} }");
+        var configuration = OfficeStamperConfigurations.minimal();
+        var stamper = docxPackageStamper(configuration);
+        var result = stamper.stamp(template, context);
+        var actual = toAsciidoc(result);
+        assertTrue(actual.contains("[1, 2, 3]"), "The inline list should be resolved to its string form");
+        assertFalse(actual.contains("${"), "The placeholder must have been consumed");
+    }
+
+    @DisplayName("SpEL inline maps can be used as placeholders (brace balancing)")
+    @Test
+    void inlineMapPlaceholderResolves() {
+        var context = mapContextFactory().empty();
+        var template = makeWordResource("Map: ${ {'a': 1, 'b': 2} }");
+        var configuration = OfficeStamperConfigurations.minimal();
+        var stamper = docxPackageStamper(configuration);
+        var result = stamper.stamp(template, context);
+        var actual = toAsciidoc(result);
+        assertTrue(actual.contains("1"), "The map value should be resolved");
+        assertTrue(actual.contains("2"), "The map value should be resolved");
+        assertFalse(actual.contains("${"), "The placeholder must have been consumed");
     }
 }


### PR DESCRIPTION
…ists/maps)

Replace the regex-based PlaceholderHooker with a single-pass brace-balanced scanner. A placeholder now ends at the closing brace that balances its opening brace, so expressions may nest braces (SpEL inline lists/maps) and a malformed placeholder whose opening brace is never balanced is captured verbatim and handed to the ExceptionResolver instead of being left behind as a stray literal.

- PlaceholderHooker: brace-balanced scanner, longest-delimiter-first
- Preprocessors.preparePlaceholders(String,String) + minimal() wiring
- ExceptionResolvers: descriptive logging on resolve
- SpelInjectionTest: makeWordResource-based regression cases
- docs updated (how-does-it-works, release-notes)