### PR TITLE
Fix #799: NPE loading decorative wps:wsp shapes without a textbox

### DIFF
--- a/utils/src/main/java/pro/verron/officestamper/utils/wml/DocxIterator.java
+++ b/utils/src/main/java/pro/verron/officestamper/utils/wml/DocxIterator.java
@@ -139,8 +139,10 @@ public class DocxIterator implements ResetableIterator<Object> {
                 iteratorQueue.add(content.iterator());
             }
             case CTWordprocessingShape ws -> {
-                var content = List.of(ws.getTxbx());
-                iteratorQueue.add(content.iterator());
+                // Decorative shapes (e.g. wps:wsp without a textbox, common in footers) have no
+                // txbx; getTxbx() is null and List.of(null) would throw an NPE. Skip them.
+                var txbx = ws.getTxbx();
+                if (txbx != null) iteratorQueue.add(List.of(txbx).iterator());
             }
             case CTTextboxInfo ti -> {
                 var content = List.of(ti.getTxbxContent());

--- a/utils/src/test/java/pro/verron/officestamper/utils/wml/DocxIteratorTest.java
+++ b/utils/src/test/java/pro/verron/officestamper/utils/wml/DocxIteratorTest.java
@@ -1,5 +1,6 @@
 package pro.verron.officestamper.utils.wml;
 
+import org.docx4j.com.microsoft.schemas.office.word.x2010.wordprocessingShape.CTWordprocessingShape;
 import org.docx4j.wml.ContentAccessor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -143,6 +144,19 @@ class DocxIteratorTest {
         assertSame(sdtBlock, iterator.next());
         assertSame(innerContent, iterator.next());
         assertSame(innermostObj, iterator.next());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    @DisplayName("next handles a WordprocessingShape that has no textbox (decorative shape) without throwing")
+    void testNextHandlesWordprocessingShapeWithoutTextbox() {
+        // A decorative wps:wsp (e.g. in footers) has no txbx, so getTxbx() is null.
+        // List.of(null) used to throw an NPE while iterating such a shape (issue #799).
+        var shape = new CTWordprocessingShape();
+        var iterator = new DocxIterator(() -> List.of(shape));
+
+        assertTrue(iterator.hasNext());
+        assertSame(shape, iterator.next());
         assertFalse(iterator.hasNext());
     }
 }


### PR DESCRIPTION
DocxIterator enqueued List.of(ws.getTxbx()) for CTWordprocessingShape nodes. Decorative shapes (e.g. wps:wsp in footers) have no txbx, so getTxbx() returns null and List.of(null) threw an NPE, aborting template loading.

Guard against a null txbx and skip such shapes. Adds a regression test.